### PR TITLE
Disable UI option

### DIFF
--- a/debezium/templates/deployment.yaml
+++ b/debezium/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 ---
+{{- if .Values.ui.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -104,3 +105,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end}}

--- a/debezium/templates/ingress.yaml
+++ b/debezium/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.ui.ingress.enabled -}}
+{{- if and .Values.ui.ingress.enabled .Values.ui.enabled -}}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/debezium/templates/service.yaml
+++ b/debezium/templates/service.yaml
@@ -15,6 +15,7 @@ spec:
   selector:
     {{- include "debezium.selectorLabels.connect" . | nindent 4 }}
 ---
+{{- if .Values.ui.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,3 +31,4 @@ spec:
       name: {{ .Values.ui.service.name}}
   selector:
     {{- include "debezium.selectorLabels.ui" . | nindent 4 }}
+{{- end}}

--- a/debezium/values.yaml
+++ b/debezium/values.yaml
@@ -43,6 +43,7 @@ connect:
       value: debezium_connect_statuses
 
 ui:
+  enabled: true
   replicaCount: 1
   imagePullSecrets: [ ]
 


### PR DESCRIPTION
This update includes an `enabled` option for the UI component, which makes the chart more flexible for users who do not want the UI component and only the Debezium connector.